### PR TITLE
Change initialization of ENABLE_BACKGROUND setting

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -90,7 +90,7 @@ export default function App() {
     [ENABLE_TIMER_ALERTS]: false,
     [FOCUS_TIME_MINUTES]: 25,
     [BREAK_TIME_MINUTES]: 5,
-    [ENABLE_BACKGROUND]: true,
+    [ENABLE_BACKGROUND]: false,
     [AUTO_APPEARANCE]: true,
     [DARK_MODE]: false,
   });


### PR DESCRIPTION
Change initial `ENABLE_BACKGROUND` setting to `false`, to prevent a network call on app startup if background is turned off