### PR TITLE
Delay initializeSettingsData call

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -356,10 +356,11 @@ export default function App() {
 
   useEffect(() => {
     // Timer and app initialiation
-    // getAndSetTimerValue(mode);
     loadTimerSound();
-    prefillSettings();
-    initializeSettingsData();
+    prefillSettings()
+      .then(() => {
+        initializeSettingsData();
+      });
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
- Delay `initializeSettingsData` call until after `prefillSettings` call has finished
  - This will read the background image setting from storage